### PR TITLE
Add net and row file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,4 +326,5 @@ poetry.toml
 
 # End of https://www.toptal.com/developers/gitignore/api/node,python,visualstudiocode
 
-*.xml
+simuration/
+src/models/data/


### PR DESCRIPTION
This commit adds the ability to generate net and row files.

The net file is generated using the number of lanes and the road length.
The row file is generated using the max speed, the number of vehicles per hour, the begin time, the end time and the edge.

The net and row files are generated in the simulation folder.
